### PR TITLE
Apply formatting rules to quoted names in command list

### DIFF
--- a/languages/nushell.scm
+++ b/languages/nushell.scm
@@ -222,7 +222,7 @@
 
 ;; data structures
 (command_list
-  (cmd_identifier) @append_space @prepend_spaced_softline
+  [(cmd_identifier) (val_string)] @append_space @prepend_spaced_softline
 )
 
 (command


### PR DESCRIPTION
The query for `command_list` didn't account for quoted command names, so I added `val_string` as an alternative to `cmd_identifier`. These should be the only possible node types here according to [the grammar](https://github.com/nushell/tree-sitter-nu/blob/41a1c570b57987386ed9a928fc214928f8ddc669/grammar.js#L114-L118).

Source:
```nushell
use module [foo bar]
use module ["foo" "bar"]
use module [foo "bar"]
use module ["foo" bar]
```

Before PR:

```nushell
use module [ foo bar ]
use module ["foo""bar"]
use module [ foo "bar"]
use module ["foo" bar ]
```

After PR:

```nushell
use module [ foo bar ]
use module [ "foo" "bar" ]
use module [ foo "bar" ]
use module [ "foo" bar ]
```