### PR TITLE
Fix source and source-env formatting

### DIFF
--- a/languages/nushell.scm
+++ b/languages/nushell.scm
@@ -190,6 +190,7 @@
   (hide_env)
   (hide_mod)
   (decl_use)
+  (stmt_source)
 ] @append_empty_softline
 
 ;; control flow


### PR DESCRIPTION
Fixes formatting of `source` and `source-env`.

Source:
```nushell
source foo
source bar
source-env fooenv
source-env barnev
```
Before this PR:
```nushell
source foo source bar source-env fooenv source-env barnev
```

After this PR:
```nushell
source foo
source bar
source-env fooenv
source-env barnev
```