### PR TITLE
feat: adapted to the latest parser

### DIFF
--- a/languages.ncl
+++ b/languages.ncl
@@ -1,13 +1,10 @@
 {
   languages = {
-    nushell = {
+    nu = {
       extensions = ["nu"],
-      grammar = {
-        source.git = {
-          git = "https://github.com/nushell/tree-sitter-nu.git",
-          rev = "7e0f16f608a9e804fae61430ade734f9f849fb80",
-        },
-        symbol = "tree_sitter_nu",
+      grammar.source.git = {
+        git = "https://github.com/nushell/tree-sitter-nu.git",
+        rev = "f85d2481616537d1d54894bc278d64b24581ea5c",
       },
     },
   },

--- a/languages/nu.scm
+++ b/languages/nu.scm
@@ -18,15 +18,45 @@
 ;; keep empty lines
 (_) @allow_blank_line_before
 
+;; TODO: temp workaround for the whitespace issue
 [
   ":"
   ";"
+  "do"
+  "if"
+  "match"
+  "try"
+  "while"
 ] @append_space
 
-;; TODO: temp solution for the whitespace issue
 [
   "="
+  (match_guard)
 ] @prepend_space
+
+(assignment
+  opr: _
+  rhs:
+  (pipeline
+    (pipe_element
+      (val_string
+        (raw_string_begin)
+      )
+    )
+  ) @prepend_space
+)
+
+(
+  "="
+  .
+  (pipeline
+    (pipe_element
+      (val_string
+        (raw_string_begin)
+      )
+    )
+  ) @prepend_space
+)
 
 [
   "->"
@@ -36,7 +66,6 @@
   "catch"
   "const"
   "def"
-  "do"
   "else"
   "error"
   "export"
@@ -45,12 +74,10 @@
   "for"
   "hide"
   "hide-env"
-  "if"
   "in"
   "let"
   "loop"
   "make"
-  "match"
   "module"
   "mut"
   "new"
@@ -58,35 +85,17 @@
   "return"
   "source"
   "source-env"
-  "try"
   "use"
   "where"
-  "while"
 ] @prepend_space @append_space
 
 (pipeline
-  "|" @prepend_space @append_space @prepend_empty_softline
+  "|" @append_space @prepend_input_softline
 )
 
 ;; add spaces to left & right sides of operators
 (expr_binary
-  opr: _ @append_space @prepend_space
-)
-
-(expr_parenthesized
-  (pipeline
-    (pipe_element
-      (expr_binary
-        opr: _ @append_empty_softline
-      )
-    )
-  )
-)
-
-(expr_binary
-  (expr_binary
-     opr: _ @append_empty_softline
-  )
+  opr: _ @append_input_softline @prepend_input_softline
 )
 
 (assignment
@@ -94,7 +103,7 @@
 )
 
 (where_command
-  opr: _ @prepend_space @append_space
+  opr: _ @append_input_softline @prepend_input_softline
 )
 
 ;; special flags
@@ -188,7 +197,7 @@
 ;; new-line
 (comment) @prepend_input_softline @append_hardline
 
-;; TODO: substantial slow down of duplicated rules
+;; TODO: substantial slow down by duplicated rules
 (nu_script
   (_)
   (_) @prepend_input_softline
@@ -237,13 +246,13 @@
 )
 
 (command
-  flag: _? @prepend_space
-  arg_str: _? @prepend_space
-  arg_spread: _? @prepend_space
-  arg: _? @prepend_space
+  flag: _? @prepend_input_softline
+  arg_str: _? @prepend_input_softline
+  arg_spread: _? @prepend_input_softline
+  arg: _? @prepend_input_softline
   redir: (_
-    file_path: _? @prepend_space
-  )? @prepend_space
+    file_path: _? @prepend_input_softline
+  )? @prepend_input_softline
 )
 
 (list_body

--- a/languages/nu.scm
+++ b/languages/nu.scm
@@ -2,7 +2,6 @@
 [
   (cell_path)
   (comment)
-  (long_flag_equals_value)
   (shebang)
   (unquoted)
   (val_binary)
@@ -24,16 +23,18 @@
   ";"
 ] @append_space
 
+;; TODO: temp solution for the whitespace issue
+[
+  "="
+] @prepend_space
+
 [
   "->"
-  "="
   "=>"
   "alias"
   "as"
-  "break"
   "catch"
   "const"
-  "continue"
   "def"
   "do"
   "else"
@@ -52,7 +53,6 @@
   "match"
   "module"
   "mut"
-  "not"
   "new"
   "overlay"
   "return"
@@ -62,24 +62,35 @@
   "use"
   "where"
   "while"
-  (comment)
 ] @prepend_space @append_space
 
-;; add spaces to left & right sides of operators
-(pipe_element
+(pipeline
   "|" @prepend_space @append_space @prepend_empty_softline
 )
 
+;; add spaces to left & right sides of operators
 (expr_binary
-  lhs: _ @append_space
-  opr: _ @append_spaced_softline ; multiline in expr_parenthesized
-  rhs: _ @prepend_space
+  opr: _ @append_space @prepend_space
+)
+
+(expr_parenthesized
+  (pipeline
+    (pipe_element
+      (expr_binary
+        opr: _ @append_empty_softline
+      )
+    )
+  )
+)
+
+(expr_binary
+  (expr_binary
+     opr: _ @append_empty_softline
+  )
 )
 
 (assignment
-  lhs: _ @append_space
-  opr: _
-  rhs: _ @prepend_space
+  opr: _ @prepend_space
 )
 
 (where_command
@@ -106,9 +117,10 @@
 [
   "["
   "("
+  "...("
+  "...["
+  "...{"
 ] @append_indent_start @append_empty_softline
-
-"{" @append_indent_start
 
 [
   "]"
@@ -116,7 +128,8 @@
   ")"
 ] @prepend_indent_end @prepend_empty_softline
 
-; change line happens after || for closure
+;;; change line happens after || for closure
+"{" @append_indent_start
 (
   "{" @append_empty_softline
   .
@@ -172,26 +185,24 @@
   (block)? @prepend_space
 )
 
-;; forced new-line
-[
-  (decl_def)
-  (decl_export)
-  (decl_extern)
-  (shebang)
-] @append_hardline
+;; new-line
+(comment) @prepend_input_softline @append_hardline
 
-[
-  (comment)
-  (pipeline)
-  (overlay_use)
-  (overlay_hide)
-  (overlay_list)
-  (overlay_new)
-  (hide_env)
-  (hide_mod)
-  (decl_use)
-  (stmt_source)
-] @append_empty_softline
+;; TODO: substantial slow down of duplicated rules
+(nu_script
+  (_)
+  (_) @prepend_input_softline
+)
+
+(block
+  (_)
+  (_) @prepend_input_softline
+)
+
+(val_closure
+  (_)
+  (_) @prepend_input_softline
+)
 
 ;; control flow
 (ctrl_if
@@ -217,28 +228,22 @@
   (default_arm)? @prepend_spaced_softline
 )
 
-(match_guard
-  "if" @prepend_space @append_space
-)
-
 ;; data structures
 (command_list
-  [(cmd_identifier) (val_string)] @append_space @prepend_spaced_softline
+  [
+    (cmd_identifier)
+    (val_string)
+  ] @append_space @prepend_spaced_softline
 )
 
 (command
   flag: _? @prepend_space
   arg_str: _? @prepend_space
+  arg_spread: _? @prepend_space
   arg: _? @prepend_space
   redir: (_
     file_path: _? @prepend_space
   )? @prepend_space
-)
-
-(command
-  arg_str: _
-  .
-  (expr_parenthesized)? @do_nothing
 )
 
 (list_body

--- a/test/expected_command.nu
+++ b/test/expected_command.nu
@@ -1,7 +1,7 @@
 # local command
-ls | get -i name
-| length;
-ls # multiline command
+ls
+| get -i name
+| length; ls # multiline command
 | length
 # external command
 ^git add (

--- a/test/expected_command.nu
+++ b/test/expected_command.nu
@@ -1,6 +1,5 @@
 # local command
-ls
-| get -i name
+ls | get -i name
 | length; ls # multiline command
 | length
 # external command

--- a/test/expected_ctrl.nu
+++ b/test/expected_ctrl.nu
@@ -11,8 +11,7 @@ for i in [1 2 3] {
 # alias
 alias ll = ls -l # alias comment
 # where
-ls
-| where $in.name == 'foo'
+ls | where $in.name == 'foo'
 | where {|e| $e.item.name !~ $'^($e.index + 1)'}
 # match
 let foo = { name: 'bar' count: 7 }

--- a/test/expected_ctrl.nu
+++ b/test/expected_ctrl.nu
@@ -2,37 +2,37 @@
 for i in [1 2 3] {
   # if
   if (true or false) {
-    print "break";
-    break # break
+    print "break"; break # break
   } else if not false {
-    print "continue";
-    continue # continue
+    print "continue"; continue # continue
   }
   return 1 # return
-} # alias
+}
+# alias
 alias ll = ls -l # alias comment
 # where
-ls | where $in.name == 'foo'
+ls
+| where $in.name == 'foo'
 | where {|e| $e.item.name !~ $'^($e.index + 1)'}
 # match
 let foo = { name: 'bar' count: 7 }
 match $foo {
-  { name: 'bar' count: $it } if $it < 5 => ($it + 3), # match arm comment
+  { name: 'bar' count: $it } if $it < 5 => ($it + 3) # match arm comment
   # match comment
-  { name: 'bar' count: $it } if not ($it >= 5) => ($it + 7),
+  { name: 'bar' count: $it } if not ($it >= 5) => ($it + 7)
   _ => {exit 0}
 }
 # while
 mut x = 0; while $x < 10 {$x = $x + 1}; $x # while comment
 # loop
 loop {
-  if $x > 10 { break };
+  if $x > 10 {break};
   $x = $x + 1
-} # try
+}
+# try
 try {
   # error
   error make -u {
     msg: 'Some error info'
   }
-};
-print 'Resuming'
+}; print 'Resuming'

--- a/test/expected_decl.nu
+++ b/test/expected_decl.nu
@@ -21,8 +21,7 @@ with-env { ABC: 'hello' } {
 let cls = {|foo bar baz|
   (
     $foo +
-    $bar +
-    $baz
+    $bar + $baz
   )
 }
 

--- a/test/expected_decl.nu
+++ b/test/expected_decl.nu
@@ -21,7 +21,8 @@ with-env { ABC: 'hello' } {
 let cls = {|foo bar baz|
   (
     $foo +
-    $bar + $baz
+    $bar +
+    $baz
   )
 }
 
@@ -38,6 +39,10 @@ def "hi there" [where: string]: nothing -> string {
 # decl_use
 use greetings.nu hello
 export use greetings.nu *
+use module [ foo bar ]
+use module [ "foo" "bar" ]
+use module [ foo "bar" ]
+use module [ "foo" bar ]
 
 # decl_module
 module greetings {

--- a/test/expected_exe.nu
+++ b/test/expected_exe.nu
@@ -14,11 +14,9 @@ def modify_args_per_workspace [
 ]: nothing -> list<string> {
   let icons = (
     aerospace list-windows --workspace $sid --json
-    | from json
-    | get app-name
+    | from json | get app-name
     | each {$in | get_icon_by_app_name}
-    | uniq
-    | sort
+    | uniq | sort
     | str join ' '
   )
   let extra = (

--- a/test/expected_exe.nu
+++ b/test/expected_exe.nu
@@ -3,6 +3,7 @@
 use constants.nu [
   colors
   get_icon_by_app_name
+  "foo bar"
 ]
 
 const animate_frames = 30
@@ -13,9 +14,11 @@ def modify_args_per_workspace [
 ]: nothing -> list<string> {
   let icons = (
     aerospace list-windows --workspace $sid --json
-    | from json | get app-name
+    | from json
+    | get app-name
     | each {$in | get_icon_by_app_name}
-    | uniq | sort
+    | uniq
+    | sort
     | str join ' '
   )
   let extra = (

--- a/test/input_decl.nu
+++ b/test/input_decl.nu
@@ -28,14 +28,17 @@ $env.hello = 'hello'
 }
 
 # decl_def
-def "hi there" [where: string]:
-nothing -> string {
+def "hi there" [where: string]: nothing -> string {
     $"hi ($where)!"
 }
 
 # decl_use
 use greetings.nu hello
 export use greetings.nu *
+use module [foo bar]
+use module ["foo" "bar"]
+use module [foo "bar"]
+use module ["foo" bar]
 
 # decl_module
 module greetings {

--- a/test/input_exe.nu
+++ b/test/input_exe.nu
@@ -3,6 +3,7 @@
 use constants.nu [
     colors
     get_icon_by_app_name
+    "foo bar"
 ]
 
 const animate_frames = 30

--- a/test/input_string.nu
+++ b/test/input_string.nu
@@ -8,5 +8,6 @@ const hybrid_help_cmd = ("Multiline
    string" +
   ($external_tldr_cmd | str replace '{}' '(foo)') +
   "another multiline
-  string" + ($help_preview_cmd | str replace '{}' '(bar)')
+  string" +
+  ($help_preview_cmd | str replace '{}' '(bar)')
 )


### PR DESCRIPTION
This PR adapted the formatter to be compatible with the latest tree-sitter-nu parser.

It contains a hack solution for the inconsistent behavior of `assignment` that is should be fixed in the future.

<img width="160" alt="image" src="https://github.com/user-attachments/assets/0d0fa7d9-1770-4d31-89c8-d6015e0a91d9" />

<img width="145" alt="image" src="https://github.com/user-attachments/assets/709743e4-5644-4744-8b44-fd64776288ca" />

```scheme
;; FIXME: temp workaround for the whitespace issue
[
  ":"
  ";"
  "do"
  "if"
  "match"
  "try"
  "while"
] @append_space

[
  "="
  (match_guard)
] @prepend_space

(assignment
  opr: _
  rhs: (pipeline
    (pipe_element
      (val_string
        (raw_string_begin)
      )
    )
  ) @prepend_space
)

(
  "="
  .
  (pipeline
    (pipe_element
      (val_string
        (raw_string_begin)
      )
    )
  ) @prepend_space
)
```