### PR TITLE
fix Nickel error: Other("missing field `git`")

### DIFF
--- a/languages.ncl
+++ b/languages.ncl
@@ -2,7 +2,8 @@
   languages = {
     nu = {
       extensions = ["nu"],
-      grammar.source.git = {
+      grammar = {
+        symbol = "tree_sitter_nu",
         git = "https://github.com/nushell/tree-sitter-nu.git",
         rev = "2a153c88d5d44d96653057c7cc14292f4e641bef",
       },


### PR DESCRIPTION
With the current HEAD, I'm having this error:

```
> topiary format tools.nu
[2025-02-27T02:20:16Z ERROR topiary] Nickel error: Other("missing field `git`")
```

It seems like the proposed change fixes this. 