### PR TITLE
make installation instructions more convenient, add chapter about setting up auto format in helix

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,15 +15,18 @@
 
 ## setup
 
-1. install topiary-cli (0.6.0+ suggested)
-2. clone this repo to `$env.XDG_CONFIG_HOME/topiary`
-3. set environment variables
-
 ```nushell
+# install topiary-cli (0.6.0+ suggested)
+cargo install --git https://github.com/tweag/topiary topiary-cli
+
+# clone this repo to `$env.XDG_CONFIG_HOME/topiary`
+git clone https://github.com/blindFS/topiary-nushell ($env.XDG_CONFIG_HOME | path join topiary)
+
+# set environment variables
 $env.TOPIARY_CONFIG_FILE = ($env.XDG_CONFIG_HOME | path join topiary languages.ncl)
 $env.TOPIARY_LANGUAGE_DIR = ($env.XDG_CONFIG_HOME | path join topiary languages)
-
 ```
+
 ## usage
 
 + `topiary format script.nu`

--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ $env.TOPIARY_LANGUAGE_DIR = ($env.XDG_CONFIG_HOME | path join topiary languages)
 
 ## usage
 
-+ `topiary format script.nu`
+```nushell
+topiary format script.nu
+```
 
 ### neovim
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,17 @@ Format on save with [conform.nvim](https://github.com/stevearc/conform.nvim):
 },
 ```
 
+### helix
+
+To format on save in Helix, add this configuration to your `helix/languages.toml`.
+
+```toml
+[[language]]
+name = "nu"
+auto-format = true
+formatter = { command = "topiary", args = ["format", "--language", "nu"] }
+```
+
 ## contribute
 
 Help to find format issues with following method (dry-run, detects parsing/idempotence/semantic breaking):

--- a/README.md
+++ b/README.md
@@ -30,7 +30,10 @@ $env.TOPIARY_LANGUAGE_DIR = ($env.XDG_CONFIG_HOME | path join topiary languages)
 ## usage
 
 + `topiary format script.nu`
-+ neovim: format on save with [conform.nvim](https://github.com/stevearc/conform.nvim):
+
+### neovim
+
+Format on save with [conform.nvim](https://github.com/stevearc/conform.nvim):
 
 ```lua
 -- lazy.nvim setup

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 
 ```nushell
 # install topiary-cli (0.6.0+ suggested)
+# for example, installing with cargo
 cargo install --git https://github.com/tweag/topiary topiary-cli
 
 # clone this repo to `$env.XDG_CONFIG_HOME/topiary`


### PR DESCRIPTION
I propose the following changes to the README:
- Make installation instructions more convenient.
- Add a chapter about setting up auto-format in Helix.
