### PR TITLE
update topiary-cli install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 ```nushell
 # e.g. installing with cargo
-cargo install --git https://github.com/tweag/topiary topiary-cli
+cargo install topiary-cli
 ```
 
 2. Clone this repo somewhere


### PR DESCRIPTION
It's now possible to install `topiary` without cloning the repository.