### PR TITLE
fix: where_predicate has the "opr" field rather than where_command

### DIFF
--- a/languages/nu.scm
+++ b/languages/nu.scm
@@ -106,7 +106,7 @@
 
 (assignment opr: _ @prepend_space)
 
-(where_command
+(where_predicate
   opr: _ @append_input_softline @prepend_input_softline
 )
 


### PR DESCRIPTION
Not sure when exactly that changed, but this fixes using topiary with nushell/tree-sitter-nu@6810930d133af12aed8fe4557935b635934ab61a.