### PR TITLE
Rework how `topiary-nushell` typically gets launched

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,22 +32,11 @@ cargo install topiary-cli
 2. Clone this repo somewhere
 
 ```nushell
-# e.g. to `$env.XDG_CONFIG_HOME/topiary`
-git clone https://github.com/blindFS/topiary-nushell ($env.XDG_CONFIG_HOME | path join topiary)
+cd ~ # Replace `~` with wherever you'd like this repo to live
+git clone https://github.com/blindFS/topiary-nushell
 ```
 
-3. Setup environment variables (Optional)
-
-> [!WARNING]
-> This is required if you want to do the formatting via vanilla topiary-cli, like in the neovim/helix settings below.
->
-> While the [`format.nu`](https://github.com/blindFS/topiary-nushell/blob/main/format.nu) script in this repo just wraps that for you.
-
-```nushell
-# Set environment variables according to the path of the clone
-$env.TOPIARY_CONFIG_FILE = ($env.XDG_CONFIG_HOME | path join topiary languages.ncl)
-$env.TOPIARY_LANGUAGE_DIR = ($env.XDG_CONFIG_HOME | path join topiary languages)
-```
+3. Add the `topiary-nushell/bin` folder to your PATH environment variable
 
 > [!WARNING]
 > For windows users, if something went wrong the first time you run the formatter,
@@ -77,14 +66,11 @@ $env.TOPIARY_LANGUAGE_DIR = ($env.XDG_CONFIG_HOME | path join topiary languages)
 
 ## Usage
 
-<details>
-  <summary>Using the <a href="https://github.com/blindFS/topiary-nushell/blob/main/format.nu">format.nu</a> wrapper </summary>
-
 ```markdown
-Helper to run topiary with the correct environment variables for topiary-nushell
+Wrapper for `topiary` that formats `nushell` files
 
 Usage:
-  > format.nu {flags} ...(files)
+  > topiary-nushell {flags} ...(files)
 
 Flags:
   -c, --config_dir <path>: Root of the topiary-nushell repo, defaults to the parent directory of this script
@@ -103,28 +89,14 @@ Input/output types:
 
 Examples:
   Read from stdin
-  > bat foo.nu | format.nu
+  > bat foo.nu | topiary-nushell
 
   Format files (in-place replacement)
-  > format.nu foo.nu bar.nu
+  > topiary-nushell foo.nu bar.nu
 
   Path overriding
-  > format.nu -c /path/to/topiary-nushell foo.nu bar.nu
+  > topiary-nushell -c /path/to/topiary-nushell foo.nu bar.nu
 ```
-
-</details>
-
-<details>
-  <summary>Using topiary-cli </summary>
-
-```nushell
-# in-place formatting
-topiary format script.nu
-# stdin -> stdout
-cat foo.nu | topiary format --language nu
-```
-
-</details>
 
 ### Locally Disable Formatting for Certain Expression
 
@@ -162,8 +134,7 @@ This will keep the let assignment as it is while formatting the rest of the code
     },
     formatters = {
       topiary_nu = {
-        command = "topiary",
-        args = { "format", "--language", "nu" },
+        command = "topiary-nushell",
       },
     },
   },
@@ -181,7 +152,7 @@ To format on save in Helix, add this configuration to your `helix/languages.toml
 [[language]]
 name = "nu"
 auto-format = true
-formatter = { command = "topiary", args = ["format", "--language", "nu"] }
+formatter = { command = "topiary-nushell" }
 ```
 
 </details>
@@ -194,7 +165,7 @@ formatter = { command = "topiary", args = ["format", "--language", "nu"] }
   "Nu": {
     "formatter": {
       "external": {
-        "command": "/path-to-the-clone/format.nu"
+        "command": "topiary-nushell"
       }
     },
     "format_on_save": "on"

--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@
 
 * [Topiary](https://github.com/tweag/topiary): tree-sitter based uniform formatter
 * This repo contains:
-  * languages.ncl: configuration that enables nushell
-  * nu.scm: tree-sitter query DSL that defines the behavior of the formatter for nushell
+  * `bin/topiary-nushell` wrapper for `topiary` that formats nushell files
+  * `languages.ncl`: configuration that enables nushell
+  * `languages/nu.scm`: tree-sitter query DSL that defines the behavior of the formatter for nushell
+  * `format.nu`: deprecated version of `bin/topiary-nushell`
   * stand-alone tests written in nushell
 
 ## Status
@@ -77,7 +79,7 @@ $env.TOPIARY_LANGUAGE_DIR = ($env.XDG_CONFIG_HOME | path join topiary languages)
 
 <details>
   <summary>Using the <a href="https://github.com/blindFS/topiary-nushell/blob/main/format.nu">format.nu</a> wrapper </summary>
-  
+
 ```markdown
 Helper to run topiary with the correct environment variables for topiary-nushell
 
@@ -114,7 +116,7 @@ Examples:
 
 <details>
   <summary>Using topiary-cli </summary>
-  
+
 ```nushell
 # in-place formatting
 topiary format script.nu
@@ -147,7 +149,7 @@ This will keep the let assignment as it is while formatting the rest of the code
 <details>
   <summary>Neovim </summary>
   Format on save with <a href="https://github.com/stevearc/conform.nvim">conform.nvim</a>:
-  
+
 ```lua
 -- lazy.nvim setup
 {

--- a/bin/topiary-nushell
+++ b/bin/topiary-nushell
@@ -1,0 +1,22 @@
+#!/usr/bin/env -S nu --stdin
+
+const script_path = path self .
+
+# Helper to run topiary with the correct environment variables for topiary-nushell
+@example "Read from stdin" { bat foo.nu | format.nu }
+@example "Format files (in-place replacement)" { format.nu foo.nu bar.nu }
+@example "Path overriding" { format.nu -c /path/to/topiary-nushell foo.nu bar.nu }
+def main [
+  --config_dir (-c): path # Root of the topiary-nushell repo, defaults to the parent directory of this script
+  ...files: path # Files to format
+]: [nothing -> nothing string -> string] {
+  let config_dir = $config_dir | default $script_path
+  $env.TOPIARY_CONFIG_FILE = ($config_dir | path join languages.ncl)
+  $env.TOPIARY_LANGUAGE_DIR = ($config_dir | path join languages)
+
+  if ($files | is-not-empty) {
+    topiary format ...$files
+  } else {
+    topiary format --language nu
+  }
+}

--- a/bin/topiary-nushell
+++ b/bin/topiary-nushell
@@ -1,6 +1,6 @@
 #!/usr/bin/env -S nu --stdin
 
-const script_path = path self .
+const repo_path = path self ..
 
 # Helper to run topiary with the correct environment variables for topiary-nushell
 @example "Read from stdin" { bat foo.nu | format.nu }
@@ -10,7 +10,7 @@ def main [
   --config_dir (-c): path # Root of the topiary-nushell repo, defaults to the parent directory of this script
   ...files: path # Files to format
 ]: [nothing -> nothing string -> string] {
-  let config_dir = $config_dir | default $script_path
+  let config_dir = $config_dir | default $repo_path
   $env.TOPIARY_CONFIG_FILE = ($config_dir | path join languages.ncl)
   $env.TOPIARY_LANGUAGE_DIR = ($config_dir | path join languages)
 

--- a/bin/topiary-nushell
+++ b/bin/topiary-nushell
@@ -2,12 +2,12 @@
 
 const repo_path = path self ..
 
-# Helper to run topiary with the correct environment variables for topiary-nushell
-@example "Read from stdin" { bat foo.nu | format.nu }
-@example "Format files (in-place replacement)" { format.nu foo.nu bar.nu }
-@example "Path overriding" { format.nu -c /path/to/topiary-nushell foo.nu bar.nu }
+# Wrapper for `topiary` that formats `nushell` files
+@example "Read from stdin" { bat foo.nu | topiary-nushell }
+@example "Format files (in-place replacement)" { topiary-nushell foo.nu bar.nu }
+@example "Path overriding" { topiary-nushell -c /path/to/topiary-nushell-repo foo.nu bar.nu }
 def main [
-  --config_dir (-c): path # Root of the topiary-nushell repo, defaults to the parent directory of this script
+  --config_dir (-c): path # Root of the topiary-nushell repo, defaults to the directory one level up from this script
   ...files: path # Files to format
 ]: [nothing -> nothing string -> string] {
   let config_dir = $config_dir | default $repo_path

--- a/bin/topiary-nushell.bat
+++ b/bin/topiary-nushell.bat
@@ -1,0 +1,3 @@
+@echo off
+SET binDir=%~dp0
+nu %binDir%topiary-nushell %*

--- a/format.nu
+++ b/format.nu
@@ -2,14 +2,15 @@
 
 const script_path = path self .
 
-# Helper to run topiary with the correct environment variables for topiary-nushell
-@example "Read from stdin" { bat foo.nu | format.nu }
-@example "Format files (in-place replacement)" { format.nu foo.nu bar.nu }
-@example "Path overriding" { format.nu -c /path/to/topiary-nushell foo.nu bar.nu }
+# DEPRECATED. Migrate to `bin/topiary-nushell` (which supports being added to the system PATH variable).
+# This `format.nu` script may be removed from the `topiary-nushell` repo in the future.
 def main [
   --config_dir (-c): path # Root of the topiary-nushell repo, defaults to the parent directory of this script
   ...files: path # Files to format
 ]: [nothing -> nothing string -> string] {
+
+  print -e "WARNING: This format.nu script is deprecated and may be removed in the future.\nMigrate to `bin/topiary-nushell`.\n"
+
   let config_dir = $config_dir | default $script_path
   $env.TOPIARY_CONFIG_FILE = ($config_dir | path join languages.ncl)
   $env.TOPIARY_LANGUAGE_DIR = ($config_dir | path join languages)


### PR DESCRIPTION
Closes https://github.com/blindFS/topiary-nushell/issues/37. The approach I took for this PR is still being debated over there, so this PR description is purely intended to document what the state of `topiary-nushell` would be if this PR was merged as-is. 

* `format.nu` is now deprecated (when it runs, it logs its deprecation to stderr, and the help text documents it as deprecation)
*  The replacement is `bin/topiary-nushell`, and the `bin` folder should be added to the user's PATH variable as a part of installation.
* It's no longer recommended to clone `topiary-nushell` to the location that the user's topiary config lives.
* The `topiary-nushell` wrapper is recommended for use over cloning this repo to `~/.config/topiary`

TODO: Additional testing of the `topiary-nushell.bat` wrapper to verify that arguments still work correctly for Windows users (I need to do the tree-sitter compilation workaround)